### PR TITLE
Consec characters restrict

### DIFF
--- a/Readme.markdown
+++ b/Readme.markdown
@@ -24,9 +24,9 @@ TODO List
 -------
 
 - Accept username/email address optionally and check that variations of it are not contained in password
-- Regexes enforcing Owasp standards (enforcing character class uses)
-- Regexes preventing the most commons patterns of passwords i.e. 'Broncos1!' style (see video/linked articles)
-- Allowing loading of lists of most widely used passwords on internet to be blacklisted
+- Regexes preventing the most commons topologies of passwords i.e. 'Broncos1!' style (see video/linked articles)
+- Min topology change between old/new passwords
+- Allowing loading of lists of most widely used passwords on internet to be explicitly blacklisted
 
 Relevant Posts/Articles
 ---------------------

--- a/src/main/scala/com/garymalouf/averruncus/password/ErrorProvider.scala
+++ b/src/main/scala/com/garymalouf/averruncus/password/ErrorProvider.scala
@@ -10,6 +10,7 @@ trait ErrorProvider[E] {
   val hasNumeric: E
   val hasSymbol: E
   val noWhitespace: E
+  val consecIdenticalCharsError: E
 }
 
 object ErrorProvider {
@@ -20,9 +21,9 @@ object ErrorProviders {
 
   implicit val string = new ErrorProvider[String] {
     def minLengthError(min: Int) =
-      s"Password must contain at least ${min} characters"
+      s"Password must contain at least $min characters"
     def maxLengthError(max: Int) =
-      s"Password cannot contain more than ${max} characters"
+      s"Password cannot contain more than $max characters"
     val hasUpper =
       "Password must contain at least one uppercase character"
     val hasLower =
@@ -33,6 +34,8 @@ object ErrorProviders {
       "Password must contain at least one non-alphanumeric character"
     val noWhitespace =
       "Password must not contain any whitespace characters"
+    val consecIdenticalCharsError =
+      "Password must not contain more than 3 identical characters in a row"
   }
 
   implicit val stringNel = new ErrorProvider[Rules.StringNel] {
@@ -50,5 +53,7 @@ object ErrorProviders {
       NonEmptyList(string.hasSymbol)
     val noWhitespace =
       NonEmptyList(string.noWhitespace)
+    val consecIdenticalCharsError =
+      NonEmptyList(string.consecIdenticalCharsError)
   }
 }

--- a/src/main/scala/com/garymalouf/averruncus/password/PasswordValidator.scala
+++ b/src/main/scala/com/garymalouf/averruncus/password/PasswordValidator.scala
@@ -14,33 +14,39 @@ object Rules {
   def maxLength[E: ErrorProvider](max: Int): Rule[E, String] =
     Rule(ErrorProvider[E].maxLengthError(max), (_: String).length <= max)
 
-  def reTest[E: ErrorProvider](e: E, r: Regex): Rule[E, String] =
+  def regexPosTest[E: ErrorProvider](e: E, r: Regex): Rule[E, String] =
     Rule(e, (s: String) => r.findFirstIn(s).nonEmpty)
 
   val upperR = "(?=.*[A-Z])".r
 
   def hasUpper[E: ErrorProvider]: Rule[E, String] =
-    reTest(ErrorProvider[E].hasUpper, upperR)
+    regexPosTest(ErrorProvider[E].hasUpper, upperR)
 
   val lowerR = "(?=.*[a-z])".r
 
   def hasLower[E: ErrorProvider]: Rule[E, String] =
-    reTest(ErrorProvider[E].hasLower, lowerR)
+    regexPosTest(ErrorProvider[E].hasLower, lowerR)
 
   val numR = "(?=.*[0-9])".r
 
   def hasNumeric[E: ErrorProvider]: Rule[E, String] =
-    reTest(ErrorProvider[E].hasNumeric, numR)
+    regexPosTest(ErrorProvider[E].hasNumeric, numR)
 
   val symR = """(?=.*[\W])""".r
 
   def hasSymbol[E: ErrorProvider]: Rule[E, String] =
-    reTest(ErrorProvider[E].hasSymbol, symR)
+    regexPosTest(ErrorProvider[E].hasSymbol, symR)
 
   val wsR = """^\S*$""".r
 
   def noWhitespace[E: ErrorProvider]: Rule[E, String] =
-    reTest(ErrorProvider[E].noWhitespace, wsR)
+    regexPosTest(ErrorProvider[E].noWhitespace, wsR)
+
+  val dcR = """(.)\1\1+""".r
+  // Ensures that the same character does not show up 3 times in a row or more
+  def limitConsecutiveIdenticalCharacters[E: ErrorProvider]: Rule[E, String] =
+    Rule(ErrorProvider[E].consecIdenticalCharsError, dcR.findFirstIn(_).isEmpty)
+
 }
 
 object PasswordValidator {
@@ -56,18 +62,20 @@ object PasswordValidator {
   ): G[Unit] =
     RuleRunner.run[E, String, G](rules: _*)(pw)
 
-  def validateAll[E: ErrorProvider, G[_]: Applicative](min: Int, max: Int)(
+  def validateAll[E: ErrorProvider, G[_]: Applicative](minLength: Int, maxLength: Int)(
     pw: String
   )(
     implicit
     runner: Runner[E, G]
   ): G[Unit] =
     validate[E, G](
-      Rules.minLength[E](min),
-      Rules.maxLength[E](max),
+      Rules.minLength[E](minLength),
+      Rules.maxLength[E](maxLength),
       Rules.hasUpper[E],
       Rules.hasLower[E],
       Rules.hasNumeric[E],
-      Rules.hasSymbol[E]
+      Rules.hasSymbol[E],
+      Rules.noWhitespace[E],
+      Rules.limitConsecutiveIdenticalCharacters[E]
     )(pw)
 }

--- a/src/test/scala/com/garymalouf/averruncus/password/RulesSpec.scala
+++ b/src/test/scala/com/garymalouf/averruncus/password/RulesSpec.scala
@@ -96,7 +96,7 @@ class RulesSpec extends Specification with ScalaCheck {
       }
   }
 
-  "The blah rule" should {
+  "The limitConsecutiveIdenticalCharacters rule" should {
     val posTestCases = List("ThiIsNotSmee", "aabababababa", "HelppNNow!")
 
     val negTestCases = List("HHHelpMe!", "dumpppDrumpf!", "It'sALongDayyy")

--- a/src/test/scala/com/garymalouf/averruncus/password/RulesSpec.scala
+++ b/src/test/scala/com/garymalouf/averruncus/password/RulesSpec.scala
@@ -5,6 +5,7 @@ import org.scalacheck.Gen
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Prop.forAll
 import org.specs2.ScalaCheck
+import org.specs2.execute.Result
 import org.specs2.mutable.Specification
 import scalaz.syntax.id._
 
@@ -93,5 +94,22 @@ class RulesSpec extends Specification with ScalaCheck {
         val wws = inject(si._1, si._2, List.fill(l)(" ").mkString)
         Rules.noWhitespace[Rules.StringNel].run(wws) must beFalse
       }
+  }
+
+  "The blah rule" should {
+    val posTestCases = List("ThiIsNotSmee", "aabababababa", "HelppNNow!")
+
+    val negTestCases = List("HHHelpMe!", "dumpppDrumpf!", "It'sALongDayyy")
+    "return true if pw does not have 3+ consecutive, identical characters" >> {
+      Result.foreach(posTestCases) { pw =>
+        Rules.limitConsecutiveIdenticalCharacters[Rules.StringNel].run(pw) must beTrue
+      }
+    }
+
+    "return false if pw has 3+ consecutive, identical characters" >> {
+      Result.foreach(negTestCases) { pw =>
+        Rules.limitConsecutiveIdenticalCharacters[Rules.StringNel].run(pw) must beFalse
+      }
+    }
   }
 }


### PR DESCRIPTION
Prevent a user from entering more than 3 consecutive, identical characters.  Hard-coded as anything more than 3 makes the library pointless, while can be annoying for an end user.